### PR TITLE
Feat/decode parse options

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "#value-object": "./dist/value-object.js"
     },
     "scripts": {
+        "clean": "rm -rf dist",
+        "prebuild": "npm run clean",
         "build": "tsc --project tsconfig.build.json",
         "check": "biome check .",
         "format": "biome format . --write",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "#value-object": "./dist/value-object.js"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc --project tsconfig.build.json",
         "check": "biome check .",
         "format": "biome format . --write",
         "lint": "biome lint .",

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -4,6 +4,7 @@ import {
 	decodeUnknown,
 	decodeUnknownSync,
 	optional,
+	optionalWith,
 	Struct,
 } from "effect/Schema";
 import type { ParseOptions } from "effect/SchemaAST";
@@ -21,37 +22,37 @@ import { Skill } from "./resume/skill.js";
 
 namespace Resume {
 	export const Schema = Struct({
-		awards: optional(ArraySchema(Award.Schema)).annotations({
+		awards: optionalWith(ArraySchema(Award.Schema), { exact: true }).annotations({
 			identifier: "awards",
 		}),
 		basics: Basics.Schema.annotations({
 			identifier: "basics",
 		}),
-		certificates: optional(ArraySchema(Certificate.Schema)).annotations({
+		certificates: optionalWith(ArraySchema(Certificate.Schema), { exact: true }).annotations({
 			identifier: "certificates",
 		}),
-		education: optional(ArraySchema(Education.Schema)).annotations({
+		education: optionalWith(ArraySchema(Education.Schema), { exact: true }).annotations({
 			identifier: "education",
 		}),
-		interests: optional(ArraySchema(Interest.Schema)).annotations({
+		interests: optionalWith(ArraySchema(Interest.Schema), { exact: true }).annotations({
 			identifier: "interests",
 		}),
-		languages: optional(ArraySchema(Language.Schema)).annotations({
+		languages: optionalWith(ArraySchema(Language.Schema), { exact: true }).annotations({
 			identifier: "languages",
 		}),
-		meta: optional(Meta.Schema).annotations({
+		meta: optionalWith(Meta.Schema, { exact: true }).annotations({
 			identifier: "meta",
 		}),
-		initiatives: optional(ArraySchema(Initiative.Schema)).annotations({
+		initiatives: optionalWith(ArraySchema(Initiative.Schema), { exact: true }).annotations({
 			identifier: "initiatives",
 		}),
-		publications: optional(ArraySchema(Publication.Schema)).annotations({
+		publications: optionalWith(ArraySchema(Publication.Schema), { exact: true }).annotations({
 			identifier: "publications",
 		}),
-		skills: optional(ArraySchema(Skill.Schema)).annotations({
+		skills: optionalWith(ArraySchema(Skill.Schema), { exact: true }).annotations({
 			identifier: "skills",
 		}),
-		employments: optional(ArraySchema(Employment.Schema)).annotations({
+		employments: optionalWith(ArraySchema(Employment.Schema), { exact: true }).annotations({
 			identifier: "employments",
 		}),
 	});

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,13 +1,4 @@
-import { Effect } from "effect";
-import {
-	Array as ArraySchema,
-	decodeUnknown,
-	decodeUnknownSync,
-	optional,
-	optionalWith,
-	Struct,
-} from "effect/Schema";
-import type { ParseOptions } from "effect/SchemaAST";
+import { Effect, Schema as EffectSchema, type SchemaAST } from "effect";
 import { Award } from "./resume/award.js";
 import { Basics } from "./resume/basics.js";
 import { Certificate } from "./resume/certificate.js";
@@ -21,49 +12,56 @@ import { Publication } from "./resume/publication.js";
 import { Skill } from "./resume/skill.js";
 
 namespace Resume {
-	export const Schema = Struct({
-		awards: optionalWith(ArraySchema(Award.Schema), { exact: true }).annotations({
-			identifier: "awards",
+	export const Schema = EffectSchema.Struct({
+		awards: EffectSchema.optionalWith(EffectSchema.Array(Award.Schema), {
+			exact: true,
 		}),
-		basics: Basics.Schema.annotations({
-			identifier: "basics",
+		basics: Basics.Schema,
+		certificates: EffectSchema.optionalWith(
+			EffectSchema.Array(Certificate.Schema),
+			{
+				exact: true,
+			},
+		),
+		education: EffectSchema.optionalWith(EffectSchema.Array(Education.Schema), {
+			exact: true,
 		}),
-		certificates: optionalWith(ArraySchema(Certificate.Schema), { exact: true }).annotations({
-			identifier: "certificates",
+		interests: EffectSchema.optionalWith(EffectSchema.Array(Interest.Schema), {
+			exact: true,
 		}),
-		education: optionalWith(ArraySchema(Education.Schema), { exact: true }).annotations({
-			identifier: "education",
+		languages: EffectSchema.optionalWith(EffectSchema.Array(Language.Schema), {
+			exact: true,
 		}),
-		interests: optionalWith(ArraySchema(Interest.Schema), { exact: true }).annotations({
-			identifier: "interests",
+		meta: EffectSchema.optionalWith(Meta.Schema, { exact: true }),
+		initiatives: EffectSchema.optionalWith(
+			EffectSchema.Array(Initiative.Schema),
+			{ exact: true },
+		),
+		publications: EffectSchema.optionalWith(
+			EffectSchema.Array(Publication.Schema),
+			{ exact: true },
+		),
+		skills: EffectSchema.optionalWith(EffectSchema.Array(Skill.Schema), {
+			exact: true,
 		}),
-		languages: optionalWith(ArraySchema(Language.Schema), { exact: true }).annotations({
-			identifier: "languages",
-		}),
-		meta: optionalWith(Meta.Schema, { exact: true }).annotations({
-			identifier: "meta",
-		}),
-		initiatives: optionalWith(ArraySchema(Initiative.Schema), { exact: true }).annotations({
-			identifier: "initiatives",
-		}),
-		publications: optionalWith(ArraySchema(Publication.Schema), { exact: true }).annotations({
-			identifier: "publications",
-		}),
-		skills: optionalWith(ArraySchema(Skill.Schema), { exact: true }).annotations({
-			identifier: "skills",
-		}),
-		employments: optionalWith(ArraySchema(Employment.Schema), { exact: true }).annotations({
-			identifier: "employments",
-		}),
+		employments: EffectSchema.optionalWith(
+			EffectSchema.Array(Employment.Schema),
+			{ exact: true },
+		),
+	}).annotations({
+		identifier: "Resume",
 	});
 
 	export type Type = typeof Schema.Type;
 
-	export const decodeAsync = (json: unknown, options?: ParseOptions) =>
-		decodeUnknown(Schema, options)(json).pipe(Effect.runPromise);
+	export const decodeAsync = (
+		json: unknown,
+		options?: SchemaAST.ParseOptions,
+	) =>
+		EffectSchema.decodeUnknown(Schema, options)(json).pipe(Effect.runPromise);
 
-	export const decodeSync = (json: unknown, options?: ParseOptions) =>
-		decodeUnknownSync(Schema, options)(json);
+	export const decodeSync = (json: unknown, options?: SchemaAST.ParseOptions) =>
+		EffectSchema.decodeUnknownSync(Schema, options)(json);
 }
 
 export {

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,10 +1,12 @@
-import { Effect } from "effect/index";
+import { Effect } from "effect";
 import {
 	Array as ArraySchema,
 	decodeUnknown,
+	decodeUnknownSync,
 	optional,
 	Struct,
 } from "effect/Schema";
+import type { ParseOptions } from "effect/SchemaAST";
 import { Award } from "./resume/award.js";
 import { Basics } from "./resume/basics.js";
 import { Certificate } from "./resume/certificate.js";
@@ -56,10 +58,11 @@ namespace Resume {
 
 	export type Type = typeof Schema.Type;
 
-	export const decodeSync = (json: unknown) =>
-		Effect.runSync(decodeUnknown(Schema)(json));
-	export const decodeAsync = (json: unknown) =>
-		Effect.runPromise(decodeUnknown(Schema)(json));
+	export const decodeAsync = (json: unknown, options?: ParseOptions) =>
+		decodeUnknown(Schema, options)(json).pipe(Effect.runPromise);
+
+	export const decodeSync = (json: unknown, options?: ParseOptions) =>
+		decodeUnknownSync(Schema, options)(json);
 }
 
 export {

--- a/src/resume/__tests__/__snapshots__/basics.test.ts.snap
+++ b/src/resume/__tests__/__snapshots__/basics.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`should parse this Basics 1`] = `
 {
   "birth": 1975-08-12T00:00:00.000Z,
+  "drivingLicenses": [
+    "B",
+  ],
   "headline": "Vice President of IT Operations",
   "location": {
     "address": "123 Enterprise Blvd",

--- a/src/resume/__tests__/basics.test.ts
+++ b/src/resume/__tests__/basics.test.ts
@@ -19,7 +19,7 @@ it("should parse this Basics", () => {
 			countryCode: "US",
 		},
 		nationalities: ["US"],
-		driverLicenses: ["B"],
+		drivingLicenses: ["B"],
 		picture: "https://example.com/images/bill-palmer.jpg",
 		profiles: [
 			{

--- a/src/resume/award.ts
+++ b/src/resume/award.ts
@@ -16,6 +16,8 @@ export namespace Award {
 		location: optionalWith(Location.Schema, { exact: true }),
 		summary: optionalWith(Summary.FromString, { exact: true }),
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
+	}).annotations({
+		identifier: "Award",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/award.ts
+++ b/src/resume/award.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Location,
@@ -13,9 +13,9 @@ export namespace Award {
 		title: ProperNoun.FromString,
 		issuer: Organization.Schema,
 		date: Day.FromString,
-		location: optional(Location.Schema),
-		summary: optional(Summary.FromString),
-		tags: optional(ArraySchema(Tag.FromString)),
+		location: optionalWith(Location.Schema, { exact: true }),
+		summary: optionalWith(Summary.FromString, { exact: true }),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/basics.ts
+++ b/src/resume/basics.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Contact,
 	CountryCode,
@@ -17,19 +17,19 @@ import { Website } from "./basics/website.js";
 
 export namespace Basics {
 	export const Schema = Struct({
-		availability: optional(Availability),
-		birth: optional(Day.FromString),
-		drivingLicenses: optional(ArraySchema(DrivingLicense)),
-		contact: optional(Contact.Schema),
+		availability: optionalWith(Availability, { exact: true }),
+		birth: optionalWith(Day.FromString, { exact: true }),
+		drivingLicenses: optionalWith(ArraySchema(DrivingLicense), { exact: true }),
+		contact: optionalWith(Contact.Schema, { exact: true }),
 		headline: Headline,
-		picture: optional(Url.FromString),
-		location: optional(Location.Schema),
+		picture: optionalWith(Url.FromString, { exact: true }),
+		location: optionalWith(Location.Schema, { exact: true }),
 		name: ProperNoun.FromString,
-		nationalities: optional(ArraySchema(CountryCode.FromString)),
-		profiles: optional(ArraySchema(Profile.Schema)),
-		summary: optional(Summary.FromString),
-		website: optional(Website),
-		remote: optional(Remote),
+		nationalities: optionalWith(ArraySchema(CountryCode.FromString), { exact: true }),
+		profiles: optionalWith(ArraySchema(Profile.Schema), { exact: true }),
+		summary: optionalWith(Summary.FromString, { exact: true }),
+		website: optionalWith(Website, { exact: true }),
+		remote: optionalWith(Remote, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/basics.ts
+++ b/src/resume/basics.ts
@@ -25,11 +25,15 @@ export namespace Basics {
 		picture: optionalWith(Url.FromString, { exact: true }),
 		location: optionalWith(Location.Schema, { exact: true }),
 		name: ProperNoun.FromString,
-		nationalities: optionalWith(ArraySchema(CountryCode.FromString), { exact: true }),
+		nationalities: optionalWith(ArraySchema(CountryCode.FromString), {
+			exact: true,
+		}),
 		profiles: optionalWith(ArraySchema(Profile.Schema), { exact: true }),
 		summary: optionalWith(Summary.FromString, { exact: true }),
 		website: optionalWith(Website, { exact: true }),
 		remote: optionalWith(Remote, { exact: true }),
+	}).annotations({
+		identifier: "Basics",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/certificate.ts
+++ b/src/resume/certificate.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Organization,
@@ -13,9 +13,9 @@ export namespace Certificate {
 		date: Day.FromString,
 		issuer: Organization.Schema,
 		name: ProperNoun.FromString,
-		summary: optional(Summary.FromString),
-		url: optional(Url.FromString),
-		tags: optional(ArraySchema(Tag.FromString)),
+		summary: optionalWith(Summary.FromString, { exact: true }),
+		url: optionalWith(Url.FromString, { exact: true }),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/certificate.ts
+++ b/src/resume/certificate.ts
@@ -16,6 +16,8 @@ export namespace Certificate {
 		summary: optionalWith(Summary.FromString, { exact: true }),
 		url: optionalWith(Url.FromString, { exact: true }),
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
+	}).annotations({
+		identifier: "Certificate",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/education.ts
+++ b/src/resume/education.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Location,
@@ -14,14 +14,14 @@ import { StudyType } from "./education/study-type.js";
 export namespace Education {
 	export const Schema = Struct({
 		area: ProperNoun.FromString,
-		courses: optional(ArraySchema(Course)),
-		endDate: optional(Day.FromString),
+		courses: optionalWith(ArraySchema(Course), { exact: true }),
+		endDate: optionalWith(Day.FromString, { exact: true }),
 		organization: Organization.Schema,
-		location: optional(Location.Schema),
-		score: optional(Score.FromString),
+		location: optionalWith(Location.Schema, { exact: true }),
+		score: optionalWith(Score.FromString, { exact: true }),
 		startDate: Day.FromString,
 		type: StudyType,
-		url: optional(Url.FromString),
+		url: optionalWith(Url.FromString, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/education.ts
+++ b/src/resume/education.ts
@@ -22,6 +22,8 @@ export namespace Education {
 		startDate: Day.FromString,
 		type: StudyType,
 		url: optionalWith(Url.FromString, { exact: true }),
+	}).annotations({
+		identifier: "Education",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/education/course.ts
+++ b/src/resume/education/course.ts
@@ -1,10 +1,10 @@
-import { NonEmptyString, optional, Struct } from "effect/Schema";
+import { NonEmptyString, optionalWith, Struct } from "effect/Schema";
 import { ProperNoun, Summary } from "#value-object";
 
 export const Course = Struct({
-	summary: optional(Summary.FromString),
+	summary: optionalWith(Summary.FromString, { exact: true }),
 	name: ProperNoun.FromString,
-	format: optional(NonEmptyString).annotations({
+	format: optionalWith(NonEmptyString, { exact: true }).annotations({
 		description: "The format or delivery mode",
 		examples: ["Online bootcamp", "In-person", "etc"],
 	}),

--- a/src/resume/employment.ts
+++ b/src/resume/employment.ts
@@ -17,7 +17,9 @@ export namespace Employment {
 		type: Type,
 		summary: optionalWith(Summary.FromString, { exact: true }),
 		endDate: optionalWith(Day.FromString, { exact: true }),
-		highlights: optionalWith(ArraySchema(Highlight.FromString), { exact: true }),
+		highlights: optionalWith(ArraySchema(Highlight.FromString), {
+			exact: true,
+		}),
 		location: optionalWith(Location.Schema, { exact: true }),
 		organization: Organization.Schema,
 		position: Position.FromString,
@@ -25,6 +27,8 @@ export namespace Employment {
 		startDate: Day.FromString,
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		url: optionalWith(Url.FromString, { exact: true }),
+	}).annotations({
+		identifier: "Employment",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/employment.ts
+++ b/src/resume/employment.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Highlight,
@@ -15,16 +15,16 @@ import { Type } from "./employment/type.js";
 export namespace Employment {
 	export const Schema = Struct({
 		type: Type,
-		summary: optional(Summary.FromString),
-		endDate: optional(Day.FromString),
-		highlights: optional(ArraySchema(Highlight.FromString)),
-		location: optional(Location.Schema),
+		summary: optionalWith(Summary.FromString, { exact: true }),
+		endDate: optionalWith(Day.FromString, { exact: true }),
+		highlights: optionalWith(ArraySchema(Highlight.FromString), { exact: true }),
+		location: optionalWith(Location.Schema, { exact: true }),
 		organization: Organization.Schema,
 		position: Position.FromString,
-		references: optional(ArraySchema(Reference.Schema)),
+		references: optionalWith(ArraySchema(Reference.Schema), { exact: true }),
 		startDate: Day.FromString,
-		tags: optional(ArraySchema(Tag.FromString)),
-		url: optional(Url.FromString),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
+		url: optionalWith(Url.FromString, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/initiative.ts
+++ b/src/resume/initiative.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Highlight,
@@ -17,18 +17,18 @@ import { Type } from "./initiative/type.js";
 export namespace Initiative {
 	export const Schema = Struct({
 		summary: Summary.FromString,
-		endDate: optional(Day.FromString),
-		organization: optional(Organization.Schema),
-		highlights: optional(ArraySchema(Highlight.FromString)),
-		location: optional(Location.Schema),
+		endDate: optionalWith(Day.FromString, { exact: true }),
+		organization: optionalWith(Organization.Schema, { exact: true }),
+		highlights: optionalWith(ArraySchema(Highlight.FromString), { exact: true }),
+		location: optionalWith(Location.Schema, { exact: true }),
 		name: ProperNoun.FromString,
 		position: Position.FromString,
-		references: optional(ArraySchema(Reference.Schema)),
+		references: optionalWith(ArraySchema(Reference.Schema), { exact: true }),
 		startDate: Day.FromString,
-		status: optional(Status),
-		tags: optional(ArraySchema(Tag.FromString)),
+		status: optionalWith(Status, { exact: true }),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		type: Type,
-		url: optional(Url.FromString),
+		url: optionalWith(Url.FromString, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/initiative.ts
+++ b/src/resume/initiative.ts
@@ -19,7 +19,9 @@ export namespace Initiative {
 		summary: Summary.FromString,
 		endDate: optionalWith(Day.FromString, { exact: true }),
 		organization: optionalWith(Organization.Schema, { exact: true }),
-		highlights: optionalWith(ArraySchema(Highlight.FromString), { exact: true }),
+		highlights: optionalWith(ArraySchema(Highlight.FromString), {
+			exact: true,
+		}),
 		location: optionalWith(Location.Schema, { exact: true }),
 		name: ProperNoun.FromString,
 		position: Position.FromString,
@@ -29,6 +31,8 @@ export namespace Initiative {
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		type: Type,
 		url: optionalWith(Url.FromString, { exact: true }),
+	}).annotations({
+		identifier: "Initiative",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/interest.ts
+++ b/src/resume/interest.ts
@@ -1,11 +1,11 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import { ProperNoun, Summary, Tag } from "#value-object";
 
 export namespace Interest {
 	export const Schema = Struct({
-		summary: optional(Summary.FromString),
+		summary: optionalWith(Summary.FromString, { exact: true }),
 		name: ProperNoun.FromString,
-		tags: optional(ArraySchema(Tag.FromString)),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/interest.ts
+++ b/src/resume/interest.ts
@@ -6,6 +6,8 @@ export namespace Interest {
 		summary: optionalWith(Summary.FromString, { exact: true }),
 		name: ProperNoun.FromString,
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
+	}).annotations({
+		identifier: "Interest",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/language.ts
+++ b/src/resume/language.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import { CountryCode, ProperNoun } from "#value-object";
 
 import { Certification } from "./language/certification.js";
@@ -6,10 +6,10 @@ import { Fluency } from "./language/fluency.js";
 
 export namespace Language {
 	export const Schema = Struct({
-		certifications: optional(ArraySchema(Certification)),
-		fluency: optional(Fluency),
+		certifications: optionalWith(ArraySchema(Certification), { exact: true }),
+		fluency: optionalWith(Fluency, { exact: true }),
 		name: ProperNoun.FromString,
-		countryCode: optional(CountryCode.FromString),
+		countryCode: optionalWith(CountryCode.FromString, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/language.ts
+++ b/src/resume/language.ts
@@ -10,6 +10,8 @@ export namespace Language {
 		fluency: optionalWith(Fluency, { exact: true }),
 		name: ProperNoun.FromString,
 		countryCode: optionalWith(CountryCode.FromString, { exact: true }),
+	}).annotations({
+		identifier: "Language",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/meta.ts
+++ b/src/resume/meta.ts
@@ -1,12 +1,12 @@
-import { optional, Struct } from "effect/Schema";
+import { optionalWith, Struct } from "effect/Schema";
 import { Day, Url } from "#value-object";
 import { ResumeSchema } from "./meta/schema.js";
 
 export namespace Meta {
 	export const Schema = Struct({
-		canonical: optional(Url.FromString),
-		lastModified: optional(Day.FromString),
-		schema: optional(ResumeSchema),
+		canonical: optionalWith(Url.FromString, { exact: true }),
+		lastModified: optionalWith(Day.FromString, { exact: true }),
+		schema: optionalWith(ResumeSchema, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/meta.ts
+++ b/src/resume/meta.ts
@@ -7,6 +7,8 @@ export namespace Meta {
 		canonical: optionalWith(Url.FromString, { exact: true }),
 		lastModified: optionalWith(Day.FromString, { exact: true }),
 		schema: optionalWith(ResumeSchema, { exact: true }),
+	}).annotations({
+		identifier: "Meta",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/publication.ts
+++ b/src/resume/publication.ts
@@ -21,6 +21,8 @@ export namespace Publication {
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		type: Type,
 		url: optionalWith(Url.FromString, { exact: true }),
+	}).annotations({
+		identifier: "Publication",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/publication.ts
+++ b/src/resume/publication.ts
@@ -1,4 +1,4 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import {
 	Day,
 	Organization,
@@ -12,15 +12,15 @@ import { Type } from "./publication/type.js";
 
 export namespace Publication {
 	export const Schema = Struct({
-		authors: optional(ArraySchema(ProperNoun.FromString)),
-		doi: optional(Doi),
+		authors: optionalWith(ArraySchema(ProperNoun.FromString), { exact: true }),
+		doi: optionalWith(Doi, { exact: true }),
 		name: ProperNoun.FromString,
-		publisher: optional(Organization.Schema),
+		publisher: optionalWith(Organization.Schema, { exact: true }),
 		date: Day.FromString,
 		summary: Summary.FromString,
-		tags: optional(ArraySchema(Tag.FromString)),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		type: Type,
-		url: optional(Url.FromString),
+		url: optionalWith(Url.FromString, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/skill.ts
+++ b/src/resume/skill.ts
@@ -1,14 +1,14 @@
-import { Array as ArraySchema, optional, Struct } from "effect/Schema";
+import { Array as ArraySchema, optionalWith, Struct } from "effect/Schema";
 import { ProperNoun, Tag } from "#value-object";
 import { Level } from "./skill/level.js";
 import { YearsOfExperience } from "./skill/year-of-experience.js";
 
 export namespace Skill {
 	export const Schema = Struct({
-		level: optional(Level),
+		level: optionalWith(Level, { exact: true }),
 		name: ProperNoun.FromString,
-		tags: optional(ArraySchema(Tag.FromString)),
-		yearsOfExperience: optional(YearsOfExperience),
+		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
+		yearsOfExperience: optionalWith(YearsOfExperience, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/resume/skill.ts
+++ b/src/resume/skill.ts
@@ -9,6 +9,8 @@ export namespace Skill {
 		name: ProperNoun.FromString,
 		tags: optionalWith(ArraySchema(Tag.FromString), { exact: true }),
 		yearsOfExperience: optionalWith(YearsOfExperience, { exact: true }),
+	}).annotations({
+		identifier: "Skill",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/value-object/contact.ts
+++ b/src/value-object/contact.ts
@@ -1,12 +1,12 @@
-import { NonEmptyString, optional, Struct } from "effect/Schema";
+import { NonEmptyString, optionalWith, Struct } from "effect/Schema";
 import { Email } from "./email.js";
 import { Url } from "./url.js";
 
 export namespace Contact {
 	export const Schema = Struct({
-		email: optional(Email.FromString),
-		phone: optional(NonEmptyString),
-		linkedin: optional(Url.FromString),
+		email: optionalWith(Email.FromString, { exact: true }),
+		phone: optionalWith(NonEmptyString, { exact: true }),
+		linkedin: optionalWith(Url.FromString, { exact: true }),
 	}).annotations({
 		identifier: "Contact",
 		description: "Some ways to contact a person",

--- a/src/value-object/location.ts
+++ b/src/value-object/location.ts
@@ -1,14 +1,14 @@
-import { NonEmptyString, optional, Struct } from "effect/Schema";
+import { NonEmptyString, optionalWith, Struct } from "effect/Schema";
 import { CountryCode } from "./country-code.js";
 import { ProperNoun } from "./proper-noun.js";
 
 export namespace Location {
 	export const Schema = Struct({
-		address: optional(NonEmptyString),
-		city: optional(ProperNoun.FromString),
-		countryCode: optional(CountryCode.FromString),
-		postalCode: optional(NonEmptyString),
-		region: optional(NonEmptyString),
+		address: optionalWith(NonEmptyString, { exact: true }),
+		city: optionalWith(ProperNoun.FromString, { exact: true }),
+		countryCode: optionalWith(CountryCode.FromString, { exact: true }),
+		postalCode: optionalWith(NonEmptyString, { exact: true }),
+		region: optionalWith(NonEmptyString, { exact: true }),
 	}).annotations({
 		identifier: "Location",
 		description:

--- a/src/value-object/organization.ts
+++ b/src/value-object/organization.ts
@@ -1,12 +1,12 @@
-import { NonEmptyString, optional, Struct } from "effect/Schema";
+import { NonEmptyString, optionalWith, Struct } from "effect/Schema";
 import { Location } from "#value-object";
 import { ProperNoun } from "./proper-noun.js";
 
 export namespace Organization {
 	export const Schema = Struct({
 		name: ProperNoun.FromString,
-		location: optional(Location.Schema),
-		description: optional(NonEmptyString),
+		location: optionalWith(Location.Schema, { exact: true }),
+		description: optionalWith(NonEmptyString, { exact: true }),
 	}).annotations({
 		identifier: "Organization",
 		title: "Organization",

--- a/src/value-object/profile.ts
+++ b/src/value-object/profile.ts
@@ -1,4 +1,4 @@
-import { Literal, NonEmptyString, optional, Struct } from "effect/Schema";
+import { Literal, NonEmptyString, optionalWith, Struct } from "effect/Schema";
 import { Url } from "./url.js";
 
 const Username = NonEmptyString.annotations({
@@ -19,7 +19,7 @@ export namespace Profile {
 			"Tiktok",
 		),
 		url: Url.FromString,
-		username: optional(Username),
+		username: optionalWith(Username, { exact: true }),
 	}).annotations({
 		identifier: "Profile",
 		description:

--- a/src/value-object/reference.ts
+++ b/src/value-object/reference.ts
@@ -9,6 +9,8 @@ export namespace Reference {
 		name: ProperNoun.FromString,
 		position: optionalWith(Position.FromString, { exact: true }),
 		testimonial: optionalWith(Testamonial, { exact: true }),
+	}).annotations({
+		identifier: "Reference",
 	});
 
 	export type Type = typeof Schema.Type;

--- a/src/value-object/reference.ts
+++ b/src/value-object/reference.ts
@@ -1,14 +1,14 @@
-import { optional, Struct } from "effect/Schema";
+import { optionalWith, Struct } from "effect/Schema";
 import { Contact, Day, Position, ProperNoun } from "#value-object";
 import { Testamonial } from "../resume/reference/testamonial.js";
 
 export namespace Reference {
 	export const Schema = Struct({
-		contact: optional(Contact.Schema),
+		contact: optionalWith(Contact.Schema, { exact: true }),
 		date: Day.FromString,
 		name: ProperNoun.FromString,
-		position: optional(Position.FromString),
-		testimonial: optional(Testamonial),
+		position: optionalWith(Position.FromString, { exact: true }),
+		testimonial: optionalWith(Testamonial, { exact: true }),
 	});
 
 	export type Type = typeof Schema.Type;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["**/__tests__/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"rootDir": "src",
 		"strict": true,
 		"esModuleInterop": true,
+		"exactOptionalPropertyTypes": true,
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true,
         "paths": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "interests" section to resume data.
  * Decoders (sync/async) now accept optional parse options.

* **Refactor**
  * Strengthened validation: optional fields now require exact shapes when present; many resume schemas gain public identifiers.

* **Bug Fixes**
  * Renamed basics field driverLicenses → drivingLicenses.

* **Chores**
  * Added clean/prebuild scripts and dedicated build tsconfig; enabled exactOptionalPropertyTypes in TypeScript.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->